### PR TITLE
dockerfile: update the list of trusted CA certificates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,11 @@ ENV PKG_CONFIG_PATH=/opt/lib/pkgconfig:/opt/lib64/pkgconfig
 ENV CFLAGS="-fexceptions -Wall -O3"
 ENV CXXFLAGS="${CFLAGS}"
 
+# Update the list of trusted CA certificates
+#
+RUN yum update -y \
+    ca-certificates
+
 # Setup Some Dirs
 #
 RUN mkdir -p \


### PR DESCRIPTION
Fixing `curl: (60) SSL certificate problem: certificate has expired` by updating ca-certificates for base image